### PR TITLE
implement issue #12 (why can't I just attach this request to that issue?)

### DIFF
--- a/data/consent.html
+++ b/data/consent.html
@@ -1,15 +1,12 @@
 <html>
-<p>This page is naughty.</p>
-<p>Would your rather open it in the "private window"</p>
-<p>
-<button>open private</button>
-<button>it's cool</button>
-</p>
-
-
-<!-- TODO, jquery?  underscore?  -->
-<script>
-// some javascript to template the actual form.
-</script>
-
+<body>
+<center>
+  <p>Visiting this page might be embarassing if someone found out.</p>
+  <p>Would your like to open it in a private browsing window?</p>
+  <p>
+    <button onClick="addon.postMessage('openInPrivate');">Use Private Window</button>
+    <button onClick="addon.postMessage('continue');">Use Normal Window</button>
+  </p>
+</center>
+</body>
 </html>

--- a/lib/bpContentPolicy.js
+++ b/lib/bpContentPolicy.js
@@ -9,6 +9,11 @@ const { Class } = require("sdk/core/heritage");
 const xpcom = require("xpcom");
 let bpCategorizer = require("bpCategorizer");
 let bpUI = require("bpUI");
+let whitelistedURIs = new Map();
+
+exports.whitelistURI = function(aURI) {
+  whitelistedURIs.set(aURI, true);
+}
 
 /**
  * Returns true if aWindow is in private browsing mode.
@@ -34,21 +39,22 @@ exports.bpContentPolicy = Class({
   shouldLoad: function(aContentType, aContentLocation, aRequestOrigin,
                        aContext, aMimeType, aExtra) {
     try {
-      console.log("shouldLoad");
       if (aContentType == Ci.nsIContentPolicy.TYPE_DOCUMENT) {
+<<<<<<< HEAD
         if (bpCategorizer.matchBlushlist(aContentLocation.spec)) {
           console.log("!!! aContext: " + aContext);
+=======
+        if (bpCategorizer.matchBlushlist(aContentLocation.spec) &&
+            !whitelistedURIs.get(aContentLocation.spec)) {
+>>>>>>> issue 12: hook consent panel into bpUI.handleNavigation
           let win = null;
           let node = null;
           if (aContext instanceof Ci.nsIDOMWindow) {
             win = aContext.QueryInterface(Ci.nsIDOMWindow);
-            console.log("!!! win: " + win);
           }
           else if (aContext instanceof Ci.nsIDOMNode) {
             node = aContext.QueryInterface(Ci.nsIDOMNode);
             win = node.ownerDocument.defaultView;
-            console.log("!!! node: " + node);
-            console.log("!!! win: " + win);
           }
           if (win && !isWindowPrivate(win)) {
             console.log("stopping load for non-private window");

--- a/lib/bpContentPolicy.js
+++ b/lib/bpContentPolicy.js
@@ -40,13 +40,8 @@ exports.bpContentPolicy = Class({
                        aContext, aMimeType, aExtra) {
     try {
       if (aContentType == Ci.nsIContentPolicy.TYPE_DOCUMENT) {
-<<<<<<< HEAD
-        if (bpCategorizer.matchBlushlist(aContentLocation.spec)) {
-          console.log("!!! aContext: " + aContext);
-=======
         if (bpCategorizer.matchBlushlist(aContentLocation.spec) &&
             !whitelistedURIs.get(aContentLocation.spec)) {
->>>>>>> issue 12: hook consent panel into bpUI.handleNavigation
           let win = null;
           let node = null;
           if (aContext instanceof Ci.nsIDOMWindow) {

--- a/lib/bpContentPolicy.js
+++ b/lib/bpContentPolicy.js
@@ -9,8 +9,17 @@ const { Class } = require("sdk/core/heritage");
 const xpcom = require("xpcom");
 let bpCategorizer = require("bpCategorizer");
 let bpUI = require("bpUI");
+
+/**
+ * A map of string -> bool indicating that the URI represented by the string
+ * should not be opened in a private window.
+ */
 let whitelistedURIs = new Map();
 
+/**
+ * Adds a URI to the list of URIs to not be opened in a private window.
+ * @Param {string} aURI the URI to be whitelisted
+ */
 exports.whitelistURI = function(aURI) {
   whitelistedURIs.set(aURI, true);
 }

--- a/lib/bpUI.js
+++ b/lib/bpUI.js
@@ -5,23 +5,66 @@
 "use strict";
 
 const windows = require("windows").browserWindows;
+const panel = require("panel");
+const data = require("self").data;
 const BROWSERURL = "chrome://browser/content/browser.xul"
+let bpContentPolicy = require("bpContentPolicy");
 
 function handleNavigation(aWindow, aURI) {
+<<<<<<< HEAD
   aWindow.openDialog("chrome://browser/content/", null,
                      "chrome,all,dialog=no,private", aURI);
+=======
+  let panel = raiseConsent(aWindow, aURI);
+  panel.show();
 }
 
-function raiseConsent(scriptdata) {
-  scriptdata = scriptdata || {};
-  let consentpanel = Panel({
-    width: 400,
-    height: 400,
+function makeOrFindPrivateWindow(options) {
+  let specialname = "blushproof-private-window";
+  console.log("this would be the private window");
+  let privates = [];
+  for (let win of windows) {
+    console.log('window name', win.name, "|", win.isPrivateBrowsing);
+    if (win.isPrivateBrowsing) {
+      privates.push(win);
+    }
+    //console.log(JSON.stringify(Object.keys(x),null,2));
+    if (win.name == specialname) {
+      return win;  // if we find the blushproof one.
+    }
+  }
+  if (privates.length) {
+    return privates[0];
+  } // some private window, if any exist.
+  // didn't find one, make it.  TODO, should be private!
+  return windowUtils.open(BROWSERURL, {name:specialname,
+      features : {
+        "menubar"    : true,
+        "titlebar"   : true,
+        "scrollbars" : true,
+        "status"     : true,
+        "toolbar"    : true,
+        "location"   : true,
+        "private"    : true}
+    });
+>>>>>>> issue 12: hook consent panel into bpUI.handleNavigation
+}
+
+function raiseConsent(aWindow, aURI) {
+  let consentpanel = panel.Panel({
+    width: 600,
+    height: 140,
     contentURL: data.url('consent.html'),
-    contentScriptOptions:  scriptdata,
-    onHide: function() {
-      let win = makeOrFindPrivateWindow();
-      win.activate();
+    onMessage: function(aMessage) {
+      if (aMessage == "openInPrivate") {
+        aWindow.openDialog(BROWSERURL, null, "chrome,all,dialog=no,private",
+                           aURI);
+      } else if (aMessage == "continue") {
+        this.hide();
+        // the async content policy api would be great for this
+        bpContentPolicy.whitelistURI(aURI);
+        aWindow.gBrowser.selectedBrowser.contentWindow.location = aURI;
+      }
     }
   });
   return consentpanel;

--- a/lib/bpUI.js
+++ b/lib/bpUI.js
@@ -15,36 +15,6 @@ function handleNavigation(aWindow, aURI) {
   panel.show();
 }
 
-function makeOrFindPrivateWindow(options) {
-  let specialname = "blushproof-private-window";
-  console.log("this would be the private window");
-  let privates = [];
-  for (let win of windows) {
-    console.log('window name', win.name, "|", win.isPrivateBrowsing);
-    if (win.isPrivateBrowsing) {
-      privates.push(win);
-    }
-    //console.log(JSON.stringify(Object.keys(x),null,2));
-    if (win.name == specialname) {
-      return win;  // if we find the blushproof one.
-    }
-  }
-  if (privates.length) {
-    return privates[0];
-  } // some private window, if any exist.
-  // didn't find one, make it.  TODO, should be private!
-  return windowUtils.open(BROWSERURL, {name:specialname,
-      features : {
-        "menubar"    : true,
-        "titlebar"   : true,
-        "scrollbars" : true,
-        "status"     : true,
-        "toolbar"    : true,
-        "location"   : true,
-        "private"    : true}
-    });
-}
-
 function raiseConsent(aWindow, aURI) {
   let consentpanel = panel.Panel({
     width: 600,

--- a/lib/bpUI.js
+++ b/lib/bpUI.js
@@ -10,11 +10,19 @@ const data = require("self").data;
 const BROWSERURL = "chrome://browser/content/browser.xul"
 let bpContentPolicy = require("bpContentPolicy");
 
+/**
+ * @param {nsIDOMWindow} aWindow The window being navigated
+ * @param {string} aURI The URI being navigated to
+ */
 function handleNavigation(aWindow, aURI) {
   let panel = raiseConsent(aWindow, aURI);
   panel.show();
 }
 
+/**
+ * @param {nsIDOMWindow} aWindow The window being navigated
+ * @param {string} aURI The URI being navigated to
+ */
 function raiseConsent(aWindow, aURI) {
   let consentpanel = panel.Panel({
     width: 600,

--- a/lib/bpUI.js
+++ b/lib/bpUI.js
@@ -11,10 +11,6 @@ const BROWSERURL = "chrome://browser/content/browser.xul"
 let bpContentPolicy = require("bpContentPolicy");
 
 function handleNavigation(aWindow, aURI) {
-<<<<<<< HEAD
-  aWindow.openDialog("chrome://browser/content/", null,
-                     "chrome,all,dialog=no,private", aURI);
-=======
   let panel = raiseConsent(aWindow, aURI);
   panel.show();
 }
@@ -47,7 +43,6 @@ function makeOrFindPrivateWindow(options) {
         "location"   : true,
         "private"    : true}
     });
->>>>>>> issue 12: hook consent panel into bpUI.handleNavigation
 }
 
 function raiseConsent(aWindow, aURI) {


### PR DESCRIPTION
Two issues with this (I'll file them as follow-ups)
1. Using Panel asserts like crazy for some reason. This appears to be a known bug in the add-on sdk: https://bugzilla.mozilla.org/show_bug.cgi?id=811837
2. Clicking "Use Normal Window" needs to whitelist a host, really, not a URL. This should be fixed when we identify blushy sites based on hosts instead of substrings.
