### PR TITLE
fix pre-commit hook checking for changed js files

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -50,7 +50,7 @@ done
 # Rebuild the xpi if any javascript files changed and add it. We could run lint
 # against js_files, but jslint is awfully picky.
 js_files=`git diff-index --name-only ${against} -- | egrep *.js$`
-if [ $js_files ]
+if [ ! -z "$js_files" ]
 then
   echo "Building xpi"
   cfx xpi


### PR DESCRIPTION
My bash complains when js_files is an empty string here. The ! -z checks for non-emptyness.
